### PR TITLE
Change badge cdn url's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mkdwv-backend
 ![David](https://img.shields.io/david/Jugendhackt/mkdwv-backend.svg?style=flat-square)
-[![Made at Jugend hackt Frankfurt 2018](https://jhbadge.com/?year=2018&evt=ffm)](https://jugendhackt.org)
+[![Made at Jugend hackt Frankfurt 2018](http://jhbadge.marvnethosted.com/?year=2018&evt=ffm)](https://jugendhackt.org)
 
 Backend für "Mit Kot die Welt verbessern" #jhffm2018 (created by [@jens1o](https://github.com/jens1o) and [@MagicMarvMan](https://github.com/MagicMarvMan))

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mkdwv-backend
 ![David](https://img.shields.io/david/Jugendhackt/mkdwv-backend.svg?style=flat-square)
-[![Made at Jugend hackt Frankfurt 2018](http://jhbadge.marvnethosted.com/?year=2018&evt=ffm)](https://jugendhackt.org)
+[![Made at Jugend hackt Frankfurt 2018](https://jhbadge.freetls.fastly.net/?year=2018&evt=ffm)](https://jugendhackt.org)
 
 Backend für "Mit Kot die Welt verbessern" #jhffm2018 (created by [@jens1o](https://github.com/jens1o) and [@MagicMarvMan](https://github.com/MagicMarvMan))


### PR DESCRIPTION
I've changed the badge's domain to the new one, which runs over Fastly (CDN).

Behind the CDN is still the same instance of the badge api.